### PR TITLE
[Feature & Test] 예약코드를 이용한 회의실 입실 기능 구현 및 테스트 코드 작성

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/com/nhnacademy/meetingroomservice/MeetingRoomServiceApplication.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/MeetingRoomServiceApplication.java
@@ -2,8 +2,10 @@ package com.nhnacademy.meetingroomservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class MeetingRoomServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/nhnacademy/meetingroomservice/adaptor/BookingAdaptor.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/adaptor/BookingAdaptor.java
@@ -1,0 +1,14 @@
+package com.nhnacademy.meetingroomservice.adaptor;
+
+import com.nhnacademy.meetingroomservice.dto.EntryRequest;
+import com.nhnacademy.meetingroomservice.dto.EntryResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@FeignClient(name="booking-service", url="http://localhost:10257", path="/api/v1/bookings")
+public interface BookingAdaptor {
+
+    @PostMapping("/{no}/enter")
+    ResponseEntity<EntryResponse> checkBooking(@PathVariable("no") Long no, @RequestBody EntryRequest entryRequest);
+}

--- a/src/main/java/com/nhnacademy/meetingroomservice/adaptor/MemberAdaptor.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/adaptor/MemberAdaptor.java
@@ -1,0 +1,17 @@
+package com.nhnacademy.meetingroomservice.adaptor;
+
+import com.nhnacademy.meetingroomservice.dto.MemberResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name="member-serivce", url="http://localhost:10255", path="/api/v1/members")
+public interface MemberAdaptor {
+
+    @GetMapping("/info/{email}")
+    ResponseEntity<MemberResponse> getMember(@PathVariable String email);
+
+    @GetMapping("/{no}/name")
+    ResponseEntity<MemberResponse> getMemberName(@PathVariable("no") Long no);
+}

--- a/src/main/java/com/nhnacademy/meetingroomservice/advice/MeetingRoomControllerAdvice.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/advice/MeetingRoomControllerAdvice.java
@@ -2,6 +2,7 @@ package com.nhnacademy.meetingroomservice.advice;
 
 import com.nhnacademy.meetingroomservice.controller.MeetingRoomController;
 import com.nhnacademy.meetingroomservice.error.ErrorResponse;
+import com.nhnacademy.meetingroomservice.exception.BookingNotFoundException;
 import com.nhnacademy.meetingroomservice.exception.MeetingRoomAlreadyExistsException;
 import com.nhnacademy.meetingroomservice.exception.MeetingRoomDoesNotExistException;
 import com.nhnacademy.meetingroomservice.exception.MeetingRoomNotFoundException;
@@ -47,6 +48,19 @@ public class MeetingRoomControllerAdvice {
 
         ErrorResponse errorResponse = new ErrorResponse(
                 meetingRoomDoesNotExistException.getMessage(),
+                HttpStatus.NOT_FOUND.value(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(BookingNotFoundException.class)
+    public ResponseEntity<ErrorResponse> bookingNotFoundException(BookingNotFoundException bookingNotFoundException, HttpServletRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                bookingNotFoundException.getMessage(),
                 HttpStatus.NOT_FOUND.value(),
                 request.getRequestURI()
         );

--- a/src/main/java/com/nhnacademy/meetingroomservice/controller/MeetingRoomController.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/controller/MeetingRoomController.java
@@ -1,8 +1,6 @@
 package com.nhnacademy.meetingroomservice.controller;
 
-import com.nhnacademy.meetingroomservice.dto.MeetingRoomRegisterRequest;
-import com.nhnacademy.meetingroomservice.dto.MeetingRoomResponse;
-import com.nhnacademy.meetingroomservice.dto.MeetingRoomUpdateRequest;
+import com.nhnacademy.meetingroomservice.dto.*;
 import com.nhnacademy.meetingroomservice.service.MeetingRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +13,7 @@ import java.util.List;
  * 회의실과 관련된 작업 API endpoints를 관리하는 컨트롤러
  */
 @RestController
-@RequestMapping("/api/v1/meeting-rooms")
+@RequestMapping("/api/v1/meeting-rooms") // prefix: /api/v1, RouteLocator Bean을 직접설정해서 Spring Cloud Gateway에서 url prefix 경로를 지정해주는 방법도 생각해볼 것.
 @RequiredArgsConstructor
 public class MeetingRoomController {
 
@@ -53,6 +51,10 @@ public class MeetingRoomController {
     }
 
 
+    /**
+     *
+     * @return 회의실 DTO 리스트 반환
+     */
     @GetMapping
     public ResponseEntity<List<MeetingRoomResponse>> getMeetingRoomList() {
         List<MeetingRoomResponse> meetingRoomResponseList = meetingRoomService.getMeetingRoomList();
@@ -92,5 +94,19 @@ public class MeetingRoomController {
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)
                 .build();
+    }
+
+    /**
+     *
+     * @param no 예약번호
+     * @param entryRequest 회의실 입실 request DTO
+     * @return 회의실 입실 검증 성공 시 EntryResponse DTO 반환
+     */
+    @PostMapping("/{meeting-room-id}/verify")
+    public ResponseEntity<EntryResponse> enterMeetingRoom(@PathVariable("meeting-room-id") Long no, @RequestBody EntryRequest entryRequest) {
+        EntryResponse entryResponse = meetingRoomService.enterMeetingRoom(no, entryRequest.getCode(), entryRequest.getEntryTime(), entryRequest.getMeetingRoomNo());
+
+        return ResponseEntity
+                .ok(entryResponse);
     }
 }

--- a/src/main/java/com/nhnacademy/meetingroomservice/dto/BookingResponse.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/dto/BookingResponse.java
@@ -1,0 +1,37 @@
+package com.nhnacademy.meetingroomservice.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class BookingResponse {
+
+    private Long no;
+
+    private String code;
+
+    @EqualsAndHashCode.Exclude
+    private LocalDateTime date;
+
+    private Integer attendeeCount;
+
+    @EqualsAndHashCode.Exclude
+    private LocalDateTime finishedAt;
+
+    @EqualsAndHashCode.Exclude
+    private LocalDateTime createdAt;
+
+    private Long mbNo;
+
+    private String mbName;
+
+    private String changeName;
+
+    private Long roomNo;
+
+    private String roomName;
+}

--- a/src/main/java/com/nhnacademy/meetingroomservice/dto/EntryRequest.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/dto/EntryRequest.java
@@ -1,0 +1,19 @@
+package com.nhnacademy.meetingroomservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class EntryRequest {
+
+    private String code;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime entryTime;
+
+    private Long meetingRoomNo;
+}

--- a/src/main/java/com/nhnacademy/meetingroomservice/dto/EntryResponse.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/dto/EntryResponse.java
@@ -1,0 +1,18 @@
+package com.nhnacademy.meetingroomservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class EntryResponse {
+
+    private String code;
+
+    private LocalDateTime entryTime;
+
+    private Long meetingRoomNo;
+
+}

--- a/src/main/java/com/nhnacademy/meetingroomservice/dto/MemberResponse.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/dto/MemberResponse.java
@@ -1,0 +1,16 @@
+package com.nhnacademy.meetingroomservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@EqualsAndHashCode
+public class MemberResponse {
+    private Long no;
+
+    private String name;
+}

--- a/src/main/java/com/nhnacademy/meetingroomservice/exception/BookingNotFoundException.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/exception/BookingNotFoundException.java
@@ -1,0 +1,7 @@
+package com.nhnacademy.meetingroomservice.exception;
+
+public class BookingNotFoundException extends RuntimeException {
+    public BookingNotFoundException() {
+        super("등록되지 않은 예약정보입니다.");
+    }
+}

--- a/src/main/java/com/nhnacademy/meetingroomservice/service/MeetingRoomService.java
+++ b/src/main/java/com/nhnacademy/meetingroomservice/service/MeetingRoomService.java
@@ -1,7 +1,9 @@
 package com.nhnacademy.meetingroomservice.service;
 
+import com.nhnacademy.meetingroomservice.dto.EntryResponse;
 import com.nhnacademy.meetingroomservice.dto.MeetingRoomResponse;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MeetingRoomService {
@@ -15,4 +17,6 @@ public interface MeetingRoomService {
     MeetingRoomResponse updateMeetingRoom(Long no, String meetingRoomName, int meetingRoomCapacity);
 
     void deleteMeetingRoom(Long no);
+
+    EntryResponse enterMeetingRoom(Long no, String code, LocalDateTime entryTime, Long meetingRoomNo);
 }


### PR DESCRIPTION

# 필독

- 필독사항 작성 

---

## 📌 관련 이슈

* Pangyo-Coffee-Legends/backlog#111

---

## 📝 작업 내용

* 회의실 ID, 사용자가 입력한 예약코드, 입실시간, 회의실 번호를 인수로 받아 booking-service API를 이용하여 입실 가능 여부 반환
* 해당 기능에 대한 테스트 코드 작성

---

## ✅ 변경 사항 요약

항목 | 변경 전 | 변경 후
-- | -- | --
예약코드 입력 | 없음 | meeting-room-service에서 BookingController의 API 호출
입실 가능 여부 | 없음 | 회의실ID, 예약코드, 입실시간, 회의실 번호를 기반으로 booking-service의 API를 통해 검증 후 입실 가능 여부 응답 DTO 반환

---

## ✅ 체크리스트

* [x] 관련 이슈 번호를 `Fixes`, `Closes`, `Resolves` 중 하나로 정확히 적었는가?
* [x] 기능/버그/요청사항과 연관된 작업이 맞는가?
* [x] 코드에 문법 오류는 없는가?
* [x] 기능이 정상 동작하는가?

---

## 💡 리뷰어 참고 사항

해당 기능은 **meeting-room-service의 `MeetingRoomController → MeetingRoomService → BookingAdaptor` 흐름을 통해** booking-service의 검증 API를 호출합니다. 테스트는 컨트롤러와 서비스 단에서 작성되었습니다.

---

## 📦 테스트 방법

1. 등록된 예약 코드를 입력하면, 정상적으로 입실 응답 DTO가 반환되는지 확인한다.
2. 예약 정보와 일치하지 않는 예약 코드를 입력하면, 404 Not Found 응답이 반환되는지 확인한다.